### PR TITLE
Add python runtime loader

### DIFF
--- a/dotenvx_runtime.py
+++ b/dotenvx_runtime.py
@@ -60,6 +60,8 @@ def load(path: str = ".env", *, override: bool = False, keys_path: Optional[str]
                 val = _decrypt(val, private_key)
             except Exception:
                 pass
+        if val.startswith(_PREFIX):
+            continue
         if key in os.environ and not override:
             loaded[key] = os.environ[key]
             continue

--- a/dotenvx_runtime.py
+++ b/dotenvx_runtime.py
@@ -1,0 +1,69 @@
+import os
+import base64
+import re
+from pathlib import Path
+from typing import Dict, Optional
+
+from ecies import decrypt
+
+_PREFIX = "encrypted:"
+
+
+def _private_key_name(path: str) -> str:
+    name = Path(path).name
+    if name == ".env":
+        return "DOTENV_PRIVATE_KEY"
+    if name.startswith(".env."):
+        env = name.split(".", 1)[1]
+        return f"DOTENV_PRIVATE_KEY_{env.upper()}"
+    return "DOTENV_PRIVATE_KEY"
+
+
+def _find_private_key(env_path: str, keys_path: Optional[str]) -> Optional[str]:
+    key_name = _private_key_name(env_path)
+    if os.getenv(key_name):
+        return os.getenv(key_name)
+
+    keys_file = Path(keys_path) if keys_path else Path(env_path).with_name(".env.keys")
+    if keys_file.exists():
+        pattern = re.compile(rf"^\s*{re.escape(key_name)}\s*=\s*(.+)")
+        for line in keys_file.read_text().splitlines():
+            m = pattern.match(line)
+            if m:
+                return m.group(1).strip()
+    return None
+
+
+def _decrypt(value: str, private_key: str) -> str:
+    if not value.startswith(_PREFIX):
+        return value
+    data = base64.b64decode(value[len(_PREFIX) :])
+    secret = bytes.fromhex(private_key)
+    return decrypt(secret, data).decode()
+
+
+def load(path: str = ".env", *, override: bool = False, keys_path: Optional[str] = None) -> Dict[str, str]:
+    env_path = Path(path)
+    if not env_path.exists():
+        raise FileNotFoundError(env_path)
+    private_key = _find_private_key(str(env_path), keys_path)
+
+    loaded: Dict[str, str] = {}
+    for line in env_path.read_text().splitlines():
+        if line.strip().startswith("#") or "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        key = key.strip()
+        val = val.strip()
+        if private_key:
+            try:
+                val = _decrypt(val, private_key)
+            except Exception:
+                pass
+        if key in os.environ and not override:
+            loaded[key] = os.environ[key]
+            continue
+        os.environ[key] = val
+        loaded[key] = val
+    return loaded
+

--- a/tests/python/test_runtime.py
+++ b/tests/python/test_runtime.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+from pathlib import Path
+import tempfile
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+import dotenvx_runtime
+
+CLI = Path(__file__).resolve().parents[2] / "src" / "cli" / "dotenvx.js"
+
+
+def test_node_encrypt_python_decrypt():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        env_file = tmp_path / ".env"
+        env_file.write_text("SECRET=shhh\n")
+
+        subprocess.run([
+            "node",
+            str(CLI),
+            "encrypt"
+        ], cwd=tmp, check=True)
+
+        content = env_file.read_text()
+        assert "SECRET=encrypted:" in content
+
+        result = dotenvx_runtime.load(str(env_file))
+        assert result["SECRET"] == "shhh"
+        assert os.environ["SECRET"] == "shhh"
+        assert not any(v.startswith("encrypted:") for v in result.values())


### PR DESCRIPTION
## Summary
- add a small `dotenvx_runtime.py` module that decrypts env vars
- run repo test suite

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ddf72f1c08330a189a28af0af6631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for loading environment variables from a `.env` file, including automatic decryption of encrypted values if a private key is available.
  - Environment variables can be loaded without overwriting existing ones unless explicitly allowed.
  - Decryption failures are handled gracefully, allowing fallback to the original value.
- **Tests**
  - Added end-to-end test verifying compatibility between Node.js encryption and Python decryption of environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->